### PR TITLE
Update world restrictions to not include seasonal (leagues & deadman)

### DIFF
--- a/soxs-autologhop/soxs-autologhop.gradle.kts
+++ b/soxs-autologhop/soxs-autologhop.gradle.kts
@@ -23,7 +23,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-version = "0.1.7"
+version = "0.1.8"
 
 project.extra["PluginName"] = "AutoLogHop"
 project.extra["PluginDescription"] = "Automatically Logout / Hop / Teleport"

--- a/soxs-autologhop/src/main/java/net/runelite/client/plugins/autologhop/AutoLogHop.java
+++ b/soxs-autologhop/src/main/java/net/runelite/client/plugins/autologhop/AutoLogHop.java
@@ -228,6 +228,7 @@ public class AutoLogHop extends Plugin {
                     w.getTypes().contains(net.runelite.http.api.worlds.WorldType.PVP) ||
                     w.getTypes().contains(net.runelite.http.api.worlds.WorldType.SKILL_TOTAL) ||
                     w.getTypes().contains(net.runelite.http.api.worlds.WorldType.BOUNTY) ||
+                    w.getTypes().contains(net.runelite.http.api.worlds.WorldType.SEASONAL) ||
                     config.membersWorlds() != w.getTypes().contains(net.runelite.http.api.worlds.WorldType.MEMBERS))
                 continue;
             return w.getId();


### PR DESCRIPTION
The plugin will occasionally attempt to hop to a league world which presents a dialogue box. This change adds leagues and deadman seasonal worlds to the logic in getValidWorld(). 